### PR TITLE
docs: Fix description of xk6-mqtt extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -221,7 +221,7 @@
   imports:
     - k6/x/sse
 - module: github.com/pmalhaire/xk6-mqtt
-  description: mqtt extension
+  description: MQTT extension
   imports:
     - k6/x/mqtt
 - module: github.com/skibum55/xk6-git


### PR DESCRIPTION
MQTT is an abbreviation, so it should be capitalized.