### PR TITLE
upgrade k6registry to v0.1.13

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: registry.json
         id: registry
-        uses: grafana/k6registry@v0.1.12
+        uses: grafana/k6registry@v0.1.13
         with:
           in: "registry.yaml"
           out: "${{ env.HTDOCS_DIR }}/registry.json"


### PR DESCRIPTION
Upgrade k6registry v0.1.13 because in this release added last modification (`timestamp`) and git clone URL (`clone_url`) repository metadata to support implementation of extension linter.
