### PR TITLE
feat: update k6registry to v0.1.33

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Generate Site
         id: generate
-        uses: grafana/k6registry@v0.1.32
+        uses: grafana/k6registry@v0.1.33
         with:
           in: "registry.yaml"
           api: "${{ env.HTDOCS_DIR }}"


### PR DESCRIPTION
Why? k6registry will include k6lint v0.2.0
k6lint v0.2.0 will include two new checkers:

- [build checker](https://github.com/grafana/k6lint/issues/9)
- [smoke checker](https://github.com/grafana/k6lint/issues/10)
