### PR TITLE
removed grafana/xk6-ts because of deprecation

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -334,13 +334,6 @@
   categories:
     - misc
   constraints: ">=0.1.0"
-- module: github.com/grafana/xk6-ts
-  description: Add TypeScript support for k6
-  imports:
-    - k6/x/ts
-  categories:
-    - misc
-  constraints: ">=0.2.4"
 - module: github.com/kelseyaubrecht/xk6-webtransport
   description: Add support for webtransport protocol
   imports:


### PR DESCRIPTION
Removed grafana/xk6-ts.

The xk6-ts extension is deprecated because its [functionality has been included in k6](https://grafana.com/docs/k6/latest/using-k6/javascript-typescript-compatibility-mode/).