### PR TITLE
Add constrains to k6/x/remotewrite

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -146,7 +146,7 @@
     - k6/x/remotewrite
   categories:
     - observability
-  constraints: ">=0.3.0"
+  constraints: ">=0.3.2"
 - module: github.com/grafana/xk6-client-tracing
   description: Client for load testing distributed tracing backends
   imports:


### PR DESCRIPTION
`k6/x/remotewrite` versions `<v0.3.2` do not compile with any of the supported versions of `k6` (`>=v0.55.0`)