### PR TITLE
Get Github App secrets from vault

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -194,12 +194,19 @@ jobs:
       - publish
     if: ${{ ( github.ref_name == 'main' && needs.generate.outputs.changed == 'true' ) || inputs.force_changed }}
     steps:
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          # Also stored in 1Password as "k6 Cloud CI/CD Secrets" (Vault is write-only)
+          repo_secrets: |
+            K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_ID=k6-extension-reg-change-notifier:app_id
+            K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_PEM=k6-extension-reg-change-notifier:private_key
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_ID }}
-          private-key: ${{ secrets.K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_PEM }}
+          app-id: ${{ env.K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_ID }}
+          private-key: ${{ env.K6_EXTENSION_REGISTRY_CHANGE_NOTIFIER_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Dispatch event
         continue-on-error: true


### PR DESCRIPTION
This is a recommended setting to re-enable Github Apps after recent security incident