### PR TITLE
Add xk6-sftp extension to registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -520,3 +520,10 @@
     - k6/x/banner
   categories:
     - misc
+- module: github.com/ogarciacar/xk6-sftp
+  description: SFTP extension for k6
+  imports:
+    - k6/x/sftp
+  categories:
+    - protocol
+    - data


### PR DESCRIPTION
### Motivation
This pull request adds the xk6-sftp extension to the k6 extension registry.

#### Extension details:

- **Module:** github.com/ogarciacar/xk6-sftp

- **Description:** SFTP extension for k6

- **Imports:** k6/x/sftp

- **Categories:** protocol, data

The extension enables k6 to interact with SFTP servers, allowing scenarios such as file uploads/downloads as part of load testing workflows.

Let me know if any changes are needed!

---
Closes #66 