### PR TITLE
Add xk6-ldap to the registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -548,3 +548,11 @@
     - k6/x/amqp
   categories:
     - protocol
+- module: github.com/kressnick25/xk6-ldap
+  description: Load-testing for the LDAP protocol
+  imports:
+    - k6/x/ldap
+  categories:
+    - protocol
+    - data
+


### PR DESCRIPTION
## Extension details
- module: [github.com/kressnick25/xk6-ldap](https://github.com/kressnick25/xk6-ldap)
- description: Load-testing for the LDAP protocol
- imports: k6/x/ldap
- categories: protocol, data

This extension allows k6 to interact with Lightweight Directory Access Protocol (LDAP) servers, including binding, searching and modifying data.

Thanks!