### PR TITLE
The k6-docs repo should not receive extension-registry-changed

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -189,7 +189,6 @@ jobs:
         repo:
           - k6-extension-registry-wayback
           - k6-extension-list
-          - k6-docs
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Removed the `k6-docs` repo from the recipients of the `extension-registry-changed` event.

The list of extensions will need to be updated manually from now on, as the decision was made at the **Binary Provisioning - GA sync** meeting on **2025-08-06** that the k6 extension catalog will be edited manually.
