### PR TITLE
pin k6registry version

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Setup k6registry
         uses: grafana/k6-extension-actions/setup-k6registry@v0.1.0
+        with:
+          k6registry-version: v0.2.6
 
       - name: Run k6registry
         id: generate


### PR DESCRIPTION
Pin the k6registry version to avoid breaking the workflow when a new version is released.