### PR TITLE
fix version format

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -6,12 +6,12 @@
   imports:
     - k6
   versions:
-    - "1.0.0"
-    - "1.1.0"
-    - "1.2.0"
-    - "1.2.1"
-    - "1.2.2"
-    - "1.2.3"
+    - "v1.0.0"
+    - "v1.1.0"
+    - "v1.2.0"
+    - "v1.2.1"
+    - "v1.2.2"
+    - "v1.2.3"
 
 # Official extensions
 
@@ -21,7 +21,7 @@
   imports:
     - k6/x/remotewrite
   versions:
-    - "0.3.2"
+    - "v0.3.2"
 
 - module: github.com/grafana/xk6-faker
   description: Generate fake data in your tests
@@ -29,11 +29,11 @@
   imports:
     - k6/x/faker
   versions:
-    - "0.4.0"
-    - "0.4.1"
-    - "0.4.2"
-    - "0.4.3"
-    - "0.4.4"
+    - "v0.4.0"
+    - "v0.4.1"
+    - "v0.4.2"
+    - "v0.4.3"
+    - "v0.4.4"
 
 - module: github.com/grafana/xk6-loki
   description: Test Grafana Loki log ingestion endpoints
@@ -41,8 +41,8 @@
   imports:
     - k6/x/loki
   versions:
-    - "1.0.0"
-    - "1.0.1"
+    - "v1.0.0"
+    - "v1.0.1"
 
 - module: github.com/grafana/xk6-sql
   description: Load-test SQL Servers
@@ -50,12 +50,12 @@
   imports:
     - k6/x/sql
   versions:
-    - "1.0.0"
-    - "1.0.1"
-    - "1.0.2"
-    - "1.0.3"
-    - "1.0.4"
-    - "1.0.5"
+    - "v1.0.0"
+    - "v1.0.1"
+    - "v1.0.2"
+    - "v1.0.3"
+    - "v1.0.4"
+    - "v1.0.5"
 
 - module: github.com/grafana/xk6-sql-driver-mysql
   description: xk6-sql driver extension for MySQL database support
@@ -63,9 +63,9 @@
   imports:
     - k6/x/sql/driver/mysql
   versions:
-    - "0.1.0"
-    - "0.2.0"
-    - "0.2.1"
+    - "v0.1.0"
+    - "v0.2.0"
+    - "v0.2.1"
 
 - module: github.com/grafana/xk6-sql-driver-postgres
   description: xk6-sql driver extension for Postgres database support
@@ -73,8 +73,8 @@
   imports:
     - k6/x/sql/driver/postgres
   versions:
-    - "0.1.0"
-    - "0.1.1"
+    - "v0.1.0"
+    - "v0.1.1"
 
 - module: github.com/grafana/xk6-ssh
   description: Use SSH connections in your tests
@@ -82,10 +82,10 @@
   imports:
     - k6/x/ssh
   versions:
-    - "0.1.0"
-    - "0.1.1"
-    - "0.1.2"
-    - "0.1.3"
+    - "v0.1.0"
+    - "v0.1.1"
+    - "v0.1.2"
+    - "v0.1.3"
 
 # Community extensions
 
@@ -95,7 +95,7 @@
   imports:
     - k6/x/kafka
   versions:
-    - "1.0.0"
+    - "v1.0.0"
 
 - module: github.com/grafana/xk6-sql-driver-azuresql
   description: xk6-sql driver extension for Microsoft Azure SQL database support
@@ -103,8 +103,8 @@
   imports:
     - k6/x/sql/driver/azuresql
   versions:
-    - "0.1.0"
-    - "0.1.1"
+    - "v0.1.0"
+    - "v0.1.1"
 
 - module: github.com/grafana/xk6-sql-driver-clickhouse
   description: xk6-sql driver extension for ClickHouse database support
@@ -112,8 +112,8 @@
   imports:
     - k6/x/sql/driver/clickhouse
   versions:
-    - "0.1.0"
-    - "0.1.1"
+    - "v0.1.0"
+    - "v0.1.1"
 
 - module: github.com/grafana/xk6-sql-driver-sqlserver
   description: xk6-sql driver extension for Microsoft SQL Server database support
@@ -121,8 +121,8 @@
   imports:
     - k6/x/sql/driver/sqlserver
   versions:
-    - "0.1.0"
-    - "0.1.1"
+    - "v0.1.0"
+    - "v0.1.1"
 
 - module: github.com/phymbert/xk6-sse
   description: Server Sent Event
@@ -130,5 +130,5 @@
   imports:
     - k6/x/sse
   versions:
-    - "0.1.10"
-    - "0.1.11"
+    - "v0.1.10"
+    - "v0.1.11"


### PR DESCRIPTION
change version format to include a leading `v` as expected by go when resolving versions.