### PR TITLE
Register xk6-dns as an official extension 

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -23,6 +23,14 @@
   versions:
     - "v0.3.2"
 
+- module: github.com/grafana/xk6-dns
+  description: DNS resolution and lookups in your tests
+  tier: official
+  imports:
+    - k6/x/dns
+  versions:
+    - "v1.0.0"
+
 - module: github.com/grafana/xk6-faker
   description: Generate fake data in your tests
   tier: official


### PR DESCRIPTION
This pull request adds a new module to the `registry.yaml` file, expanding the available official modules for use in tests.

New official module added:

* Added `github.com/grafana/xk6-dns` as an official module, enabling DNS resolution and lookups in tests, with support for importing `k6/x/dns` and version `v1.0.0`.