### PR TITLE
install xk6 in workflow

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           go-version: "1.24.x"
 
+      - name: Setup xk6
+        run: >
+          go install go.k6.io/xk6@v1.2.2
+
       - name: Setup k6registry
         run: >
            go install github.com/grafana/k6registry/cmd/k6registry@v0.4.0

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -53,8 +53,9 @@ jobs:
           go-version: "1.24.x"
 
       - name: Setup xk6
-        run: >
-          go install go.k6.io/xk6@v1.2.2
+        uses: grafana/setup-xk6@v1.0.0
+        with:
+          xk6-version: v1.2.2
 
       - name: Setup k6registry
         run: >

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup xk6
         uses: grafana/setup-xk6@v1.0.0
         with:
-          xk6-version: v1.2.2
+          xk6-version: 1.2.2
 
       - name: Setup k6registry
         run: >

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -57,6 +57,13 @@ jobs:
         with:
           xk6-version: 1.2.2
 
+      - name: Setup xk6 lint dependencies
+        run: |
+           go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+           go install github.com/securego/gosec/v2/cmd/gosec@v2.22.10
+
+
+
       - name: Setup k6registry
         run: >
            go install github.com/grafana/k6registry/cmd/k6registry@v0.4.0


### PR DESCRIPTION
After changes introduced in https://github.com/grafana/k6-extension-registry/pull/113 xk6 is a requirement for the workflow