### PR TITLE
Register xk6-mqtt as official extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -45,6 +45,14 @@
     - "v1.0.0"
     - "v1.0.1"
 
+- module: github.com/grafana/xk6-mqtt
+  description: MQTT protocol support for k6
+  tier: official
+  imports:
+    - k6/x/mqtt
+  versions:
+    - "v0.1.1"
+
 - module: github.com/grafana/xk6-sql
   description: Load-test SQL Servers
   tier: official


### PR DESCRIPTION
This pull request adds a new module to the `registry.yaml` file, expanding the available official modules for use in tests.

New official module added:

* Added `github.com/grafana/xk6-mqtt` as an official module, which allows the use of the MQTT protocol in k6 tests.