### PR TITLE
Register xk6-icmp as an official extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -36,6 +36,14 @@
     - "v0.4.3"
     - "v0.4.4"
 
+- module: github.com/grafana/xk6-icmp
+  description: ICMP protocol support for k6
+  tier: official
+  imports:
+    - k6/x/icmp
+  versions:
+    - "v0.1.0"
+
 - module: github.com/grafana/xk6-loki
   description: Test Grafana Loki log ingestion endpoints
   tier: official


### PR DESCRIPTION
This pull request adds a new module to the `registry.yaml` file, expanding the available official modules for use in tests.

New official module added:

* Added `github.com/grafana/xk6-icmp` as an official module, which allows the use of the ICMP protocol in k6 tests (ping currently).