### PR TITLE
Sort wiki reports by module

### DIFF
--- a/wiki/Community.md.tpl
+++ b/wiki/Community.md.tpl
@@ -4,7 +4,7 @@ Name | Description
 -----|------------
 {{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (eq $ext.tier "community") (ne $ext.module "go.k6.io/k6") -}}
-{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
+{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.owner }}/{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}
 {{ end }}
 

--- a/wiki/Community.md.tpl
+++ b/wiki/Community.md.tpl
@@ -2,7 +2,7 @@ Set of k6 extensions developed by the community, without official support.
 
 Name | Description
 -----|------------
-{{ range $idx, $ext:= .registry -}}
+{{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (eq $ext.tier "community") (ne $ext.module "go.k6.io/k6") -}}
 {{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}

--- a/wiki/Compliance.md.tpl
+++ b/wiki/Compliance.md.tpl
@@ -19,7 +19,7 @@ Compliance with the requirements expected of k6 extensions is checked by various
 
 Repository | Description | Version | Issues
 -----------|-------------|---------|--------
-{{- range $idx, $ext:= .registry -}}
+{{- range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if (ne $ext.module "go.k6.io/k6") -}}
 {{- if coll.Has $ext "compliance" -}}
 {{-   $versions := coll.Keys $ext.compliance | coll.Sort -}}

--- a/wiki/Issues.md.tpl
+++ b/wiki/Issues.md.tpl
@@ -22,7 +22,7 @@ Lists of extensions based on issues found by the compliance check. A specific ex
         "security" "The following extensions have security issues."
         "vulnerability" "The following extensions have known vulnerabilities."
  -}}
-{{- $issue_types := coll.Slice "module" "replace" "readme" "examples" "license" "git" "versions" "build" "smoke" "types" "codeowners" "security" "vulnerability" -}}
+{{- $issue_types := coll.Slice "module" "replace" "readme" "examples" "license" "git" "versions" "build" "smoke" "types" "codeowners" "security" "vulnerability" | coll.Sort -}}
 {{- range $issue_type := $issue_types -}}
 {{-   $has_extensions := false -}}
 {{-   range $idx, $ext := $.registry -}}
@@ -45,7 +45,7 @@ Lists of extensions based on issues found by the compliance check. A specific ex
 
 Repository | Description | Versions
 -----------|-------------|----------
-{{-     range $idx, $ext := $.registry }}
+{{-     range $idx, $ext := coll.Sort "module" $.registry }}
 {{-       if coll.Has $ext "compliance" -}}
 {{-         $versions_with_issue := coll.Slice -}}
 {{-         range $version, $comp := $ext.compliance -}}

--- a/wiki/JavaScript.md.tpl
+++ b/wiki/JavaScript.md.tpl
@@ -2,7 +2,7 @@ Set of k6 extensions to extend the JavaScript functionality of test scripts or a
 
 Name | Description
 -----|------------
-{{ range $idx, $ext:= .registry -}}
+{{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (has $ext "imports") ($ext.imports) (ne $ext.module "go.k6.io/k6") -}}
 {{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.owner }}/{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}

--- a/wiki/OKRs.md.tpl
+++ b/wiki/OKRs.md.tpl
@@ -39,7 +39,7 @@ The following extensions have compliance issues.
 
 Name | Description | Issues
 -----|-------------|--------
-{{- range $idx, $ext:= .registry -}}
+{{- range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (eq $ext.tier "official") (ne $ext.module "go.k6.io/k6") -}}
 {{- if coll.Has $ext "compliance" -}}
 {{-   $all_issues := coll.Slice -}}

--- a/wiki/OKRs.md.tpl
+++ b/wiki/OKRs.md.tpl
@@ -52,7 +52,7 @@ Name | Description | Issues
 {{-   end -}}
 {{-   $all_issues = $all_issues | uniq -}}
 {{-   if $all_issues }}
-{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }} | {{ range $i, $issue := $all_issues }}{{$issue}} {{end }}
+{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.owner }}/{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }} | {{ range $i, $issue := $all_issues }}{{$issue}} {{end }}
 {{-   end -}}
 {{- end -}}
 {{ end -}}

--- a/wiki/Official.md.tpl
+++ b/wiki/Official.md.tpl
@@ -2,7 +2,7 @@ Set of k6 extensions that are officially supported by Grafana.
 
 Name | Description | Availability
 -----|-------------|-------------
-{{ range $idx, $ext:= .registry -}}
+{{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (eq $ext.tier "official") (ne $ext.module "go.k6.io/k6") -}}
 {{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}

--- a/wiki/Official.md.tpl
+++ b/wiki/Official.md.tpl
@@ -4,7 +4,7 @@ Name | Description | Availability
 -----|-------------|-------------
 {{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (eq $ext.tier "official") (ne $ext.module "go.k6.io/k6") -}}
-{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
+{{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.owner }}/{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}
 {{ end }}
 

--- a/wiki/Output.md.tpl
+++ b/wiki/Output.md.tpl
@@ -2,7 +2,7 @@ Set of k6 extensions to process the metrics emitted by k6 or publish them to uns
 
 Name | Description
 -----|------------
-{{ range $idx, $ext:= .registry -}}
+{{ range $idx, $ext:= coll.Sort "module" .registry -}}
 {{ if and (has $ext "outputs") ($ext.outputs) (ne $ext.module "go.k6.io/k6") -}}
 {{ if and $ext.repo $ext.repo.url }}[{{ $ext.repo.owner }}/{{ $ext.repo.name }}]({{$ext.repo.url}}){{else}}{{ $ext.module }}{{end}} | {{ $ext.description }}
 {{ end -}}


### PR DESCRIPTION
Show extensions consistently using owner/repo (e.g `grafana/xk6-ssh`,  `mostafa/xk6-fafka`) and sort reports by this name