### PR TITLE
feat: add xk6-msgpack extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -192,3 +192,11 @@
     - k6/x/tls
   versions:
     - "v0.1.0"
+
+- module: github.com/tango-tango/xk6-msgpack
+  description: MessagePack packing and unpacking
+  tier: community
+  imports:
+    - k6/x/msgpack
+  versions:
+    - "v0.0.3"


### PR DESCRIPTION
This adds https://github.com/Tango-Tango/xk6-msgpack as a community extension.