### PR TITLE
Add subcommand catalog entries support

### DIFF
--- a/generate-api-files.sh
+++ b/generate-api-files.sh
@@ -103,7 +103,7 @@ function generate_metrics() {
 # Generate catalog from registry
 #
 # Iterates over the registry entry and generates a catalog entry for
-# each import and output defined by the extension 
+# each import, output, and subcommand defined by the extension 
 #
 # input: registry file
 # output: catalog file 
@@ -112,7 +112,7 @@ function generate_catalog() {
     local output_file=$2
     
     jq '
-        # Creates a separate arrays of key-value pairs using import and output as keys
+        # Creates a separate arrays of key-value pairs using import, output, and subcommand as keys
         # and the extension as value, and converts this array of key-value pairs to an object
         [
           .[] as $ext |
@@ -124,6 +124,12 @@ function generate_catalog() {
           .[] as $ext |
           if ($ext | has("outputs")) and $ext.outputs then
             $ext.outputs[] | {key: ., value: $ext}
+          else empty end
+        ] +
+        [
+          .[] as $ext |
+          if ($ext | has("subcommands")) and $ext.subcommands then
+            $ext.subcommands[] | {key: ("subcommand:" + .), value: $ext}
           else empty end
         ] | from_entries
     ' "$registry_file" > "$output_file"


### PR DESCRIPTION
Update the `generate_catalog()` function to generate catalog entries for
extension subcommands. This enables automatic binary provisioning for
subcommands in k6 (grafana/k6#5664).

## Changes

- Add third array processing in `generate_catalog()` to handle subcommands
- Generate catalog entries with "subcommand:<name>" key format for each
  subcommand defined in registry entries
- Subcommand catalog entries use the same extension object structure as
  imports and outputs

## Example output

For an extension with "subcommands": ["httpbin"], the catalog will include:
```json
{
  "subcommand:httpbin": {
    "module": "github.com/grafana/xk6-subcommand-httpbin",
    "description": "...",
    "repo": {...},
    "versions": [...]
  }
}
```

This allows the k6build service to resolve subcommand dependencies when
users run commands like "k6 x httpbin" without the extension being built
into their current k6 binary.

## Related

- grafana/k6#5645 - Feature request: Subcommand support in binary provisioning
- grafana/k6#5664 - Automatic binary provisioning for extension subcommands
