### PR TITLE
Add xk6-docs official extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -120,6 +120,17 @@
   versions:
     - "v1.0.0"
 
+- module: github.com/grafana/xk6-docs
+  description: Offline k6 documentation in the terminal
+  tier: official
+  subcommands:
+    - docs
+  versions:
+    - "v0.0.1"
+    - "v0.0.2"
+    - "v0.0.3"
+    - "v0.0.4"
+
 # Community extensions
 
 - module: github.com/grafana/xk6-client-prometheus-remote


### PR DESCRIPTION
## Summary

- Register `github.com/grafana/xk6-docs` as an official subcommand extension (`k6 x docs`)
- Modeled after the `xk6-subcommand-explore` entry (also a subcommand)
- Versions v0.0.1 through v0.0.4

## About xk6-docs

Offline k6 documentation in the terminal. Auto-downloads version-matched doc bundles on first run, serves from cache after. Includes fuzzy search, built-in markdown rendering (glamour), and an agent skill for AI coding assistants.

- Repo: https://github.com/grafana/xk6-docs
- CODEOWNERS: `@grafana/k6-core`
- Topics: `xk6`, `k6`
- `xk6 lint`: all 8 checks pass (security, vulnerability, module, readme, license, git, versions, build)

## Checklist

- [x] CODEOWNERS file present
- [x] `xk6` topic on repo
- [x] `xk6 lint` passes all checks
- [x] No `exec.Command` usage (pure Go: glamour for rendering, go-git for cloning)