### PR TITLE
Add xk6-docs official extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -120,6 +120,14 @@
   versions:
     - "v1.0.0"
 
+- module: github.com/grafana/xk6-docs
+  description: k6 documentation in the terminal
+  tier: official
+  subcommands:
+    - docs
+  versions:
+    - "v0.0.1"
+
 # Community extensions
 
 - module: github.com/grafana/xk6-client-prometheus-remote


### PR DESCRIPTION
## Summary

- Register `github.com/grafana/xk6-docs` as an official subcommand extension (`k6 x docs`)
- Versions v0.0.1 through v0.0.4

## About xk6-docs

k6 documentation for users and AI agents in the terminal. Auto-downloads version-matched doc bundles on first run, serves from cache after. Includes fuzzy search, built-in markdown rendering, and an agent skill for agents.

- Repo: https://github.com/grafana/xk6-docs
- CODEOWNERS: `@grafana/k6-core`
- Topics: `xk6`, `k6`

## Checklist

- [x] CODEOWNERS file present
- [x] `xk6` topic on repo
- [x] `xk6 lint` passes all checks
- [x] No `exec.Command` usage (pure Go: glamour for rendering, go-git for cloning)