### PR TITLE
Add xk6-docs v0.0.5

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -122,12 +122,13 @@
     - "v1.0.0"
 
 - module: github.com/grafana/xk6-docs
-  description: k6 documentation in the terminal
+  description: CLI k6 docs for AI agents and users. It comes with an agent skill to help AI agents to write k6 scripts with best practices.
   tier: official
   subcommands:
     - docs
   versions:
     - "v0.0.1"
+    - "v0.0.5"
 
 # Community extensions
 


### PR DESCRIPTION
Add [v0.0.5](https://github.com/grafana/xk6-docs/releases/tag/v0.0.5) of `xk6-docs` to the registry. We went from v0.0.1 to v0.0.5 due to a Go module proxy issue.