### PR TITLE
Add xk6-docs v0.0.6

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -119,6 +119,7 @@
   versions:
     - "v0.0.1"
     - "v0.0.5"
+    - "v0.0.6"
 
 # Community extensions
 


### PR DESCRIPTION
Add [v0.0.6](https://github.com/grafana/xk6-docs/releases/tag/v0.0.6) of `xk6-docs` to the registry.