### PR TITLE
Add xk6-pyre — high-performance Prometheus HTTP exporter

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -232,3 +232,11 @@
     - httpbin
   versions:
     - "v1.0.0"
+
+- module: github.com/copyleftdev/xk6-pyre
+  description: High-performance Prometheus HTTP exporter for k6 (40% faster, thread-safe)
+  tier: community
+  outputs:
+    - prometheus
+  versions:
+    - "v0.1.0"


### PR DESCRIPTION
## Summary

Adds [xk6-pyre](https://github.com/copyleftdev/xk6-pyre) to the k6 extension registry.

**xk6-pyre** is a drop-in replacement for xk6-prometheus, built for the hot path:

- **40% faster** per-sample processing (567 ns vs 921 ns)
- **42% less memory** per sample (480 B vs 832 B)
- **57% fewer allocations** (3 vs 7 per sample)
- **Thread-safe** via RWMutex (original has unprotected map access)
- **Race detector clean** (`go test -race` passes)

### Changes made

Three targeted optimizations, each backed by benchmarks:

1. Direct switch dispatch instead of method value closures
2. Pre-sized `make([]string, len)` instead of `append` on empty slice
3. Typed maps per metric kind instead of `map[string]any` with type assertions

### Benchmarks (AMD Threadripper PRO 5975WX, Go 1.24, 3 rounds x 2s)

| Benchmark | xk6-prometheus | xk6-pyre |
|-----------|---------------|----------|
| HandleSample (counter) | 921 ns, 7 allocs | **567 ns, 3 allocs** |
| Batch 1000 | 1.10 ms, 7000 allocs | **0.68 ms, 3000 allocs** |
| Concurrent | *unsafe* | **254 ns, 3 allocs** |

### Checklist

- [x] Extension builds and tests pass
- [x] Tagged release: `v0.1.0`
- [x] Output registered as `prometheus` (same as xk6-prometheus for drop-in compat)
- [x] MIT licensed