### PR TITLE
feat: add xk6-valkey community extension

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -232,3 +232,11 @@
     - httpbin
   versions:
     - "v1.0.0"
+
+- module: github.com/moko-poi/xk6-valkey
+  description: Valkey support for k6
+  tier: community
+  imports:
+    - k6/x/valkey
+  versions:
+    - "v0.1.0"


### PR DESCRIPTION
## Summary

- Register [xk6-valkey](https://github.com/moko-poi/xk6-valkey) as a community extension
- Provides Valkey support for k6 (`k6/x/valkey`)
- Initial version: v0.1.0

## Registry Requirements Checklist

Confirmed that all [registry requirements](https://grafana.com/docs/k6/latest/extensions/create/extensions-registry/) are met

- [x] README file (description, build instructions, usage, k6 compatibility)
- [x] `xk6` topic set on the repository
- [x] Permissive license (Apache 2.0)
- [x] `examples` folder included
- [x] Versioned release (v0.1.0)
- [x] Builds with recent k6 version (k6 v1.5.0)
- [x] Naming convention followed (xk6-valkey)