### PR TITLE
feat: add v2 registry source and expose /v2/ API paths

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           k6registry -v --lint --ignore-lint-errors registry.yaml --out "${HTDOCS_DIR}/registry.json"
 
+          # generate v2 registry from the separate v2 source file
+          mkdir -p "${HTDOCS_DIR}/v2"
+          k6registry -v registry-v2.yaml --out "${HTDOCS_DIR}/v2/registry.json"
+
           # check if changed from current published version
           if ! curl -fsSL "${BASE_URL}/registry.json" | diff -q "${HTDOCS_DIR}/registry.json" - >/dev/null 2>&1; then
             echo "changed=true" >> $GITHUB_OUTPUT

--- a/generate-api-files.sh
+++ b/generate-api-files.sh
@@ -135,6 +135,39 @@ function generate_catalog() {
     ' "$registry_file" > "$output_file"
 }
 
+function generate_for_dir() {
+    local dir=$1
+    local registry_file="${dir}/registry.json"
+
+    if [[ ! -f "$registry_file" ]]; then
+        return 0
+    fi
+
+    rm -rf "${dir}/"{tier,module}
+    mkdir -p "${dir}/tier"
+    mkdir -p "${dir}/module"
+
+    $LOG "Starting generation of registry API files in ${dir}..."
+
+    REGISTRY_FILE="$registry_file" BUILD_DIR="$dir" generate_module_files
+
+    $LOG "Generating ${dir}/catalog.json..."
+    generate_catalog "${registry_file}" "${dir}/catalog.json"
+
+    for tier in "${TIERS[@]}"; do
+        $LOG "Generating tier files for: ${tier} in ${dir}..."
+        mkdir -p "${dir}/tier"
+        jq --arg tier "$tier" '[.[] | select(.tier == $tier)]' "${registry_file}" > "${dir}/tier/${tier}.json"
+        generate_catalog "${dir}/tier/${tier}.json" "${dir}/tier/${tier}-catalog.json"
+        generate_metrics "${dir}/tier/${tier}.json" "${dir}/tier/${tier}-metrics.json" "${dir}/tier/${tier}-metrics.txt" "${TIMESTAMP}" "issue"
+    done
+
+    $LOG "Generating metrics for ${dir}..."
+    generate_metrics "${registry_file}" "${dir}/metrics.json" "${dir}/metrics.txt" "${TIMESTAMP}"
+
+    $LOG "Generation complete for ${dir}!"
+}
+
 function usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
@@ -205,43 +238,17 @@ if [[ ! -f "$REGISTRY_FILE" ]]; then
     exit 1
 fi
 
-# Create api directory structure
-rm -rf  "${BUILD_DIR}/"{tier,module}
-mkdir -p "${BUILD_DIR}/tier"
-mkdir -p "${BUILD_DIR}/module"
-
-$LOG "Starting generation of registry API files..."
-
-# Generate module-specific files
-generate_module_files
-
-# Generate main catalog
-$LOG "Generating ${BUILD_DIR}/catalog.json..."
-generate_catalog "${REGISTRY_FILE}" "${BUILD_DIR}/catalog.json"
+# Generate v1 API files
+generate_for_dir "${BUILD_DIR}"
 
 # generate product/cloud-catalog.json to ensure backwards compatibility
 mkdir -p "${BUILD_DIR}/product"
 cp "${BUILD_DIR}/catalog.json" "${BUILD_DIR}/product/cloud-catalog.json"
 
-# Generate tier-based files
-for tier in "${TIERS[@]}"; do
-    $LOG "Generating tier files for: ${tier}..."
-    
-    # Create tier directory
-    mkdir -p "${BUILD_DIR}/tier"
-    
-    # Generate tier registry file (as per spec: /tier/{tier}.json)
-    jq --arg tier "$tier" '[.[] | select(.tier == $tier)]' "${REGISTRY_FILE}" > "${BUILD_DIR}/tier/${tier}.json"
-    
-    # Generate tier cataLOG file (as per spec: /tier/{tier}-catalog.json)
-    generate_catalog "${BUILD_DIR}/tier/${tier}.json" "${BUILD_DIR}/tier/${tier}-catalog.json"
+# Generate v2 API files if registry-v2.json has been pre-generated into build/v2/
+if [[ -f "${BUILD_DIR}/v2/registry.json" ]]; then
+    $LOG "Found v2 registry, generating v2 API files..."
+    generate_for_dir "${BUILD_DIR}/v2"
+fi
 
-    # Generate metrics for tier
-    generate_metrics "${BUILD_DIR}/tier/${tier}.json" "${BUILD_DIR}/tier/${tier}-metrics.json" "${BUILD_DIR}/tier/${tier}-metrics.txt" "${TIMESTAMP}" "issue"
-done
-
-$LOG "Generating metrics"
-generate_metrics  "${BUILD_DIR}/registry.json" "${BUILD_DIR}/metrics.json" "${BUILD_DIR}/metrics.txt" "${TIMESTAMP}"
-
-$LOG "Generation complete!"
 $LOG "Generated files in: ${BUILD_DIR}"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Query subsets of the registry
   - name: metrics
     description: Registry metrics queries
+  - name: v2
+    description: k6 v2-compatible extensions
 paths:
   /registry.json:
     get:
@@ -203,6 +205,109 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Metrics"
+
+  /v2/registry.json:
+    get:
+      tags:
+        - v2
+        - global
+      summary: k6 v2 registry
+      description: Download the registry of k6 v2-compatible extensions as a single JSON file
+      operationId: v2Registry
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Registry"
+  /v2/catalog.json:
+    get:
+      tags:
+        - v2
+        - catalog
+      summary: k6 v2 catalog
+      description: Download the catalog of k6 v2-compatible extensions as a single JSON file
+      operationId: v2Catalog
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Catalog"
+  /v2/metrics.json:
+    get:
+      tags:
+        - v2
+        - metrics
+      summary: k6 v2 registry metrics
+      description: Download the k6 v2 registry metrics as a single JSON file
+      operationId: v2Metrics
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Metrics"
+  /v2/module/{module}/extension.json:
+    get:
+      tags:
+        - v2
+        - module
+      summary: Query a k6 v2-compatible extension
+      description: Query the data of a specific k6 v2-compatible extension
+      operationId: v2Extension
+      parameters:
+        - $ref: "#/components/parameters/module"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Extension"
+        "404":
+          description: module not found
+  /v2/tier/{tier}.json:
+    get:
+      tags:
+        - v2
+        - subset
+      summary: k6 v2 registry subset by tier
+      description: Query the k6 v2 registry subset for a given support tier
+      operationId: v2SubsetByTier
+      parameters:
+        - $ref: "#/components/parameters/tier"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Registry"
+        "404":
+          description: tier not found
+  /v2/tier/{tier}-catalog.json:
+    get:
+      tags:
+        - v2
+        - catalog
+      summary: k6 v2 catalog subset by tier
+      description: Query the k6 v2 catalog for a given support tier
+      operationId: v2CatalogByTier
+      parameters:
+        - $ref: "#/components/parameters/tier"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Catalog"
+        "404":
+          description: tier not found
 
 components:
   schemas:

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -5,6 +5,8 @@
   tier: official
   imports:
     - k6
+  versions:
+    - v0.0.0+2a014daaa
 
 # Official extensions
 
@@ -13,3 +15,5 @@
   tier: official
   imports:
     - k6/x/faker
+  versions:
+    - v0.0.0+051eb6d3ce9a

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -1,0 +1,15 @@
+# k6 v2
+
+- module: go.k6.io/k6/v2
+  description: A modern load testing tool, using Go and JavaScript
+  tier: official
+  imports:
+    - k6
+
+# Official extensions
+
+- module: github.com/grafana/xk6-faker
+  description: Generate fake data in your tests
+  tier: official
+  imports:
+    - k6/x/faker

--- a/testdata/catalog-v2.json
+++ b/testdata/catalog-v2.json
@@ -1,0 +1,14 @@
+{
+  "k6": {
+    "module": "go.k6.io/k6/v2",
+    "versions": [
+      "v0.0.0+2a014daaa"
+    ]
+  },
+  "k6/x/faker": {
+    "module": "github.com/grafana/xk6-faker",
+    "versions": [
+      "v0.0.0+051eb6d3ce9a"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds `registry-v2.yaml` as a separate source file for k6 v2-compatible extensions and wires up the full pipeline to generate and serve a `/v2/` API path tree alongside the existing v1 paths.

## Why

k6 v2 uses a separate module path (`go.k6.io/k6/v2`) and extensions must be explicitly ported to it. Rather than adding a `k6_versions` field to the existing registry schema, v2 compatibility is expressed by which source file an extension appears in — `registry.yaml` for v1, `registry-v2.yaml` for v2. k6registry is invoked once per file, requiring no schema changes.

## How

- **`registry-v2.yaml`** — new source file listing v2-compatible extensions. Currently contains `go.k6.io/k6/v2` and `github.com/grafana/xk6-faker` with explicit `v0.0.0+<gitsha>` versions (the format used for canary and pre-release builds).

- **`generate-api-files.sh`** — refactored to share generation logic via a `generate_for_dir()` function. When `build/v2/registry.json` is present it generates the full `/v2/` path tree (catalog, tiers, modules, metrics) using the same logic as v1.

- **`openapi.yaml`** — six new paths under `/v2/` mirroring the v1 structure (`/v2/registry.json`, `/v2/catalog.json`, `/v2/metrics.json`, `/v2/module/{module}/extension.json`, `/v2/tier/{tier}.json`, `/v2/tier/{tier}-catalog.json`).

- **`.github/workflows/update.yml`** — generates `v2/registry.json` from `registry-v2.yaml` using k6registry before running `generate-api-files.sh`, so the full `/v2/` tree is built and published in CI.

- **`testdata/catalog-v2.json`** — k6build-format catalog generated from `registry-v2.yaml`, used to validate the registry→catalog pipeline and as a test fixture for k6build.

## ⚠️ Not ready to merge

This PR is open for review and discussion but **will not be merged as-is**. The `registry-v2.yaml` currently contains placeholder `v0.0.0+<gitsha>` versions for testing purposes. Before this can be published, all of the following must be in place:

- grafana/k6registry#336 merged — so CI can process `registry-v2.yaml` correctly
- A tagged `v2.x.x` release of `go.k6.io/k6/v2` — the registry entry for k6 itself needs a proper published version
- Stable releases of ported extensions (e.g. grafana/xk6-faker#98) with versions that declare `go.k6.io/k6/v2` as their k6 dependency
- `registry-v2.yaml` updated from SHA-based versions to those published releases

## Related PRs

- grafana/k6registry#336 — teaches k6registry to recognise `go.k6.io/k6/v2` as a valid k6 module path (required for the CI step that processes `registry-v2.yaml`)
- grafana/k6build#318 — consumes the catalog format produced here
- grafana/xk6-faker#98 — first extension ported to `go.k6.io/k6/v2`