### PR TITLE
Add xk6-docs v0.0.8

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -121,6 +121,7 @@
     - "v0.0.5"
     - "v0.0.6"
     - "v0.0.7"
+    - "v0.0.8"
 
 # Community extensions
 


### PR DESCRIPTION
Add [v0.0.8](https://github.com/grafana/xk6-docs/releases/tag/v0.0.8) of `xk6-docs` to the registry.