### PR TITLE
Update k6registry to v0.5.5

### DIFF
--- a/.github/actions/k6registry_setup/action.yml
+++ b/.github/actions/k6registry_setup/action.yml
@@ -22,4 +22,4 @@ runs:
     - name: Setup k6registry
       shell: bash
       run: >
-          go install github.com/grafana/k6registry/cmd/k6registry@v0.5.3
+          go install github.com/grafana/k6registry/cmd/k6registry@v0.5.5


### PR DESCRIPTION
Bumps k6registry from v0.5.3 to v0.5.5. Includes grafana/k6registry#336: recognise `go.k6.io/k6/v2` as a valid k6 module path. Required for v2 registry generation (PR #219).