### PR TITLE
Fix v2 catalog: use buildable k6 commit

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -6,7 +6,7 @@
   imports:
     - k6
   versions:
-    - v0.0.0+2a014daaa
+    - v0.0.0+43b6303a377a
 
 # Official extensions
 

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -16,4 +16,4 @@
   imports:
     - k6/x/faker
   versions:
-    - v0.0.0+051eb6d3ce9a
+    - v0.5.0


### PR DESCRIPTION
## What?

Updates the k6 commit hash in `registry-v2.yaml` so `k6@v2` extension builds actually compile.

## Why?

[`k6@2a014daaa`](https://github.com/grafana/k6/commit/2a014daaa) pointed to an intermediate PR branch commit that references symbols not present at that point in history, failing every `k6@v2` build on staging at compilation. Confirmed locally with `k6build local` and on the staging build service after grafana/deployment_tools#571755 deployed. The new hash is `k6@master` tip with the properly merged grafana/k6#5891.

## Related PR(s)/Issue(s)

- #219
- #223
- grafana/k6#5891
- grafana/deployment_tools#571755