### PR TITLE
feat: add k6 v2 compatible extensions to the v2 catalog

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -17,3 +17,67 @@
     - k6/x/faker
   versions:
     - v0.5.0
+
+- module: github.com/grafana/xk6-mqtt
+  description: MQTT protocol support for k6
+  tier: official
+  imports:
+    - k6/x/mqtt
+  versions:
+    - v0.3.0
+
+- module: github.com/grafana/xk6-redis
+  description: Extension for Redis database
+  tier: official
+  imports:
+    - k6/x/redis
+  versions:
+    - v0.4.0
+
+- module: github.com/grafana/xk6-ssh
+  description: Use SSH connections in your tests
+  tier: official
+  imports:
+    - k6/x/ssh
+  versions:
+    - v0.2.0
+
+- module: github.com/grafana/xk6-dns
+  description: DNS resolution and lookups in your tests
+  tier: official
+  imports:
+    - k6/x/dns
+  versions:
+    - v1.1.0
+
+- module: github.com/grafana/xk6-icmp
+  description: ICMP protocol support for k6
+  tier: official
+  imports:
+    - k6/x/icmp
+  versions:
+    - v0.3.0
+
+- module: github.com/grafana/xk6-sql
+  description: Load-test SQL Servers
+  tier: official
+  imports:
+    - k6/x/sql
+  versions:
+    - v1.1.0
+
+- module: github.com/grafana/xk6-subcommand-explore
+  description: Explore k6 extensions for Automatic Resolution
+  tier: official
+  subcommands:
+    - explore
+  versions:
+    - v1.1.0
+
+- module: github.com/grafana/xk6-tcp
+  description: TCP protocol support for k6
+  tier: official
+  imports:
+    - k6/x/tcp
+  versions:
+    - v0.3.0

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -10,6 +10,14 @@
 
 # Official extensions
 
+- module: github.com/grafana/xk6-dns
+  description: DNS resolution and lookups in your tests
+  tier: official
+  imports:
+    - k6/x/dns
+  versions:
+    - v1.1.0
+
 - module: github.com/grafana/xk6-faker
   description: Generate fake data in your tests
   tier: official
@@ -17,6 +25,14 @@
     - k6/x/faker
   versions:
     - v0.5.0
+
+- module: github.com/grafana/xk6-icmp
+  description: ICMP protocol support for k6
+  tier: official
+  imports:
+    - k6/x/icmp
+  versions:
+    - v0.3.0
 
 - module: github.com/grafana/xk6-mqtt
   description: MQTT protocol support for k6
@@ -34,30 +50,6 @@
   versions:
     - v0.4.0
 
-- module: github.com/grafana/xk6-ssh
-  description: Use SSH connections in your tests
-  tier: official
-  imports:
-    - k6/x/ssh
-  versions:
-    - v0.2.0
-
-- module: github.com/grafana/xk6-dns
-  description: DNS resolution and lookups in your tests
-  tier: official
-  imports:
-    - k6/x/dns
-  versions:
-    - v1.1.0
-
-- module: github.com/grafana/xk6-icmp
-  description: ICMP protocol support for k6
-  tier: official
-  imports:
-    - k6/x/icmp
-  versions:
-    - v0.3.0
-
 - module: github.com/grafana/xk6-sql
   description: Load-test SQL Servers
   tier: official
@@ -65,6 +57,14 @@
     - k6/x/sql
   versions:
     - v1.1.0
+
+- module: github.com/grafana/xk6-ssh
+  description: Use SSH connections in your tests
+  tier: official
+  imports:
+    - k6/x/ssh
+  versions:
+    - v0.2.0
 
 - module: github.com/grafana/xk6-subcommand-explore
   description: Explore k6 extensions for Automatic Resolution


### PR DESCRIPTION
This PR expands the k6 v2 extension catalog by adding official extensions that already publish k6 v2-compatible releases.

The new entries were added to `registry-v2.yaml` by reusing the existing metadata from `registry.yaml` and limiting each `versions` array to the single compatible v2 release.

## Changes

Added the following official extensions to `registry-v2.yaml`:

- `github.com/grafana/xk6-mqtt` [v0.3.0](https://github.com/grafana/xk6-mqtt/releases/tag/v0.3.0)
- `github.com/grafana/xk6-redis` [v0.4.0](https://github.com/grafana/xk6-redis/releases/tag/v0.4.0)
- `github.com/grafana/xk6-ssh` [v0.2.0](https://github.com/grafana/xk6-ssh/releases/tag/v0.2.0)
- `github.com/grafana/xk6-dns` [v1.1.0](https://github.com/grafana/xk6-dns/releases/tag/v1.1.0)
- `github.com/grafana/xk6-icmp` [v0.3.0](https://github.com/grafana/xk6-icmp/releases/tag/v0.3.0)
- `github.com/grafana/xk6-sql` [v1.1.0](https://github.com/grafana/xk6-sql/releases/tag/v1.1.0)
- `github.com/grafana/xk6-subcommand-explore` [v1.1.0](https://github.com/grafana/xk6-subcommand-explore/releases/tag/v1.1.0)
- `github.com/grafana/xk6-tcp` [v0.3.0](https://github.com/grafana/xk6-tcp/releases/tag/v0.3.0)
