### PR TITLE
Add xk6-docs v0.0.9 to v2 registry

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -74,6 +74,14 @@
   versions:
     - v1.1.0
 
+- module: github.com/grafana/xk6-docs
+  description: CLI k6 docs for AI agents and users
+  tier: official
+  subcommands:
+    - docs
+  versions:
+    - v0.0.9
+
 - module: github.com/grafana/xk6-tcp
   description: TCP protocol support for k6
   tier: official


### PR DESCRIPTION
xk6-docs v0.0.9 switched to `go.k6.io/k6/v2` module path imports (grafana/xk6-docs#42).

Registers it in the v2 catalog so `k6 x docs` works for k6 v2 users through the build service.