### PR TITLE
feat: add MySQL and Postgres driver extensions to the v2 catalog

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -58,6 +58,22 @@
   versions:
     - v1.1.0
 
+- module: github.com/grafana/xk6-sql-driver-mysql
+  description: xk6-sql driver extension for MySQL database support
+  tier: official
+  imports:
+    - k6/x/sql/driver/mysql
+  versions:
+    - v0.3.0
+
+- module: github.com/grafana/xk6-sql-driver-postgres
+  description: xk6-sql driver extension for Postgres database support
+  tier: official
+  imports:
+    - k6/x/sql/driver/postgres
+  versions:
+    - v0.2.0
+
 - module: github.com/grafana/xk6-ssh
   description: Use SSH connections in your tests
   tier: official


### PR DESCRIPTION
This PR expands the k6 v2 extension catalog by adding MySQL and Postgres SQL driver extensions.

The new entries were added to `registry-v2.yaml` by reusing the existing metadata from `registry.yaml` and limiting each `versions` array to the single compatible v2 release.

## Changes

Added the following official extensions to `registry-v2.yaml`:

- xk6-sql-driver-postgres [v0.2.0](https://github.com/grafana/xk6-sql-driver-postgres/releases/tag/v0.2.0)
- xk6-sql-driver-mysql [v0.3.0](https://github.com/grafana/xk6-sql-driver-mysql/releases/tag/v0.3.0)

