### PR TITLE
Add xk6-docs v0.0.9

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -122,6 +122,7 @@
     - "v0.0.6"
     - "v0.0.7"
     - "v0.0.8"
+    - "v0.0.9"
 
 - module: github.com/grafana/xk6-tcp
   description: TCP protocol support for k6


### PR DESCRIPTION
Add [v0.0.9](https://github.com/grafana/xk6-docs/releases/tag/v0.0.9) of `xk6-docs` to the registry.