### PR TITLE
List grafana/mcp-k6 as a subcommand extension

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -112,4 +112,4 @@
   subcommands:
     - mcp
   versions:
-    - v0.6.0
+    - v0.6.1

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -105,3 +105,11 @@
     - k6/x/tcp
   versions:
     - v0.3.0
+
+- module: github.com/grafana/mcp-k6
+  description: An MCP server for k6 for AI agents
+  tier: official
+  subcommands:
+    - mcp
+  versions:
+    - v0.6.0


### PR DESCRIPTION
github.com/grafana/mcp-k6 can now be used as a subcommand extension allowing users to spawn an MCP server for k6 with `k6 x mcp`. This extension requires k6 v2.0.0-rc1 and above