### PR TITLE
Add the xk6-subcommand-agent to extension registry

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -88,7 +88,7 @@
   subcommands:
     - agent
   versions:
-    - v0.1.1
+    - v0.1.2
 
 - module: github.com/grafana/xk6-subcommand-explore
   description: Explore k6 extensions for Automatic Resolution

--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -82,6 +82,14 @@
   versions:
     - v0.2.0
 
+- module: github.com/grafana/xk6-subcommand-agent
+  description: Bootstrap an AI-assisted k6 testing workflow in any editor
+  tier: official
+  subcommands:
+    - agent
+  versions:
+    - v0.1.1
+
 - module: github.com/grafana/xk6-subcommand-explore
   description: Explore k6 extensions for Automatic Resolution
   tier: official


### PR DESCRIPTION
This pull request adds a new official subcommand module to the registry configuration for k6. The main change is the inclusion of the `xk6-subcommand-agent` module, which supports AI-assisted testing workflows.

New official module added:

* Added the `github.com/grafana/xk6-subcommand-agent` module, including its description, tier, supported subcommand (`agent`), and version (`v0.1.2`) to the `registry-v2.yaml` file.