### PR TITLE
Add xk6-subcommand-explore v1.2.0

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -97,6 +97,7 @@
     - explore
   versions:
     - v1.1.0
+    - v1.2.0
 
 - module: github.com/grafana/xk6-docs
   description: CLI k6 docs for AI agents and users


### PR DESCRIPTION
Add [v1.2.0](https://github.com/grafana/xk6-subcommand-explore/releases/tag/v1.2.0) of `xk6-subcommand-explore` to the v2 registry.