### PR TITLE
Add xk6-llm (community)

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -242,3 +242,11 @@
     - httpbin
   versions:
     - "v1.0.0"
+
+- module: github.com/msradam/xk6-llm
+  description: Load test OpenAI-compatible LLM inference servers. Streaming TTFT/ITL/TPOT, goodput, cost, and energy metrics.
+  tier: community
+  imports:
+    - k6/x/llm
+  versions:
+    - "v0.1.0"


### PR DESCRIPTION
Adding a community extension for load-testing OpenAI-compatible LLM inference servers.

- Repo: https://github.com/msradam/xk6-llm
- Module: `github.com/msradam/xk6-llm`
- Tag: `v0.1.0`
- License: Apache-2.0
- `xk6` topic added on the repo

Emits streaming TTFT / ITL / TPOT, goodput and per-SLO Rate metrics, plus optional cost and energy estimates per request. Cross-checked against `vllm bench serve` on vLLM 0.21.0: mean TPOT, ITL, and E2EL agree within 5% on identical workloads. Notes in [docs/validation-parity.md](https://github.com/msradam/xk6-llm/blob/main/docs/validation-parity.md).

Happy to adjust the entry if anything's off.