### PR TITLE
add xk6-kv community extension entry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -242,3 +242,11 @@
     - httpbin
   versions:
     - "v1.0.0"
+
+- module: github.com/oshokin/xk6-kv
+  description: Mutable local test-data pools, leases, and response capture for k6
+  tier: community
+  imports:
+    - k6/x/kv
+  versions:
+    - "v1.4.30"


### PR DESCRIPTION
## Summary
- Register `github.com/oshokin/xk6-kv` in `registry.yaml` as a `community` extension.
- Add JavaScript import path: `k6/x/kv`.
- Add current release version: `v1.4.30`.

## Why this should be in the registry
`xk6-kv` fills a practical k6 gap: mutable, process-local data coordination between VUs/scenarios (leases, unique allocation, one-shot queues, CSV/JSONL import/export).  
This is useful when `SharedArray` is not enough (read-only) and external infra (e.g. Redis) is unnecessary.

## Scope and risk
- Metadata-only change (single file: `registry.yaml`).
- No changes to registry logic, scripts, or existing extension entries.
- Low risk; straightforward rollback if needed.

## Validation
- Module path is valid: `github.com/oshokin/xk6-kv`.
- Import path matches extension API: `k6/x/kv`.
- Extension-side compliance checks passed before submission (`xk6 lint --preset community`).
- Entry follows current registry structure.