### PR TITLE
chore: bump k6 v2 extension versions in registry-v2.yaml

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -25,6 +25,7 @@
     - k6/x/faker
   versions:
     - v0.5.0
+    - v0.5.2
 
 - module: github.com/grafana/xk6-icmp
   description: ICMP protocol support for k6
@@ -33,6 +34,7 @@
     - k6/x/icmp
   versions:
     - v0.3.0
+    - v0.3.2
 
 - module: github.com/grafana/xk6-mqtt
   description: MQTT protocol support for k6
@@ -49,6 +51,7 @@
     - k6/x/redis
   versions:
     - v0.4.0
+    - v0.4.2
 
 - module: github.com/grafana/xk6-sql
   description: Load-test SQL Servers
@@ -57,6 +60,7 @@
     - k6/x/sql
   versions:
     - v1.1.0
+    - v1.2.0
 
 - module: github.com/grafana/xk6-sql-driver-mysql
   description: xk6-sql driver extension for MySQL database support
@@ -65,6 +69,7 @@
     - k6/x/sql/driver/mysql
   versions:
     - v0.3.0
+    - v0.4.0
 
 - module: github.com/grafana/xk6-sql-driver-postgres
   description: xk6-sql driver extension for Postgres database support
@@ -73,6 +78,7 @@
     - k6/x/sql/driver/postgres
   versions:
     - v0.2.0
+    - v0.3.0
 
 - module: github.com/grafana/xk6-ssh
   description: Use SSH connections in your tests
@@ -81,6 +87,7 @@
     - k6/x/ssh
   versions:
     - v0.2.0
+    - v0.2.2
 
 - module: github.com/grafana/xk6-subcommand-agent
   description: Bootstrap an AI-assisted k6 testing workflow in any editor


### PR DESCRIPTION
Adds newly released, k6 v2.0.0-compatible versions for extensions **already listed** in `registry-v2.yaml`. Append-only — no new module entries.

| module | added version |
|---|---|
| xk6-faker | v0.5.2 |
| xk6-icmp | v0.3.2 |
| xk6-redis | v0.4.2 |
| xk6-sql | v1.2.0 |
| xk6-sql-driver-mysql | v0.4.0 |
| xk6-sql-driver-postgres | v0.3.0 |
| xk6-ssh | v0.2.2 |

All correspond to published releases now built against k6 v2.0.0 (stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)