### PR TITLE
Add version v1.1.2 to k6/x/dns module

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -17,6 +17,7 @@
     - k6/x/dns
   versions:
     - v1.1.0
+    - v1.1.2
 
 - module: github.com/grafana/xk6-faker
   description: Generate fake data in your tests


### PR DESCRIPTION
This pull request makes a minor update to the `registry-v2.yaml` file by adding the new version `v1.1.2` for the `k6/x/dns` module.