### PR TITLE
feat: add xk6-kubernetes v0.12.0 to registry-v2

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -131,3 +131,13 @@
     - mcp
   versions:
     - v0.6.1
+
+# Community extensions
+
+- module: github.com/grafana/xk6-kubernetes
+  description: A k6 extension for interacting with Kubernetes clusters while testing.
+  tier: community
+  imports:
+    - k6/x/kubernetes
+  versions:
+    - v0.12.0


### PR DESCRIPTION
## Summary
- Add `github.com/grafana/xk6-kubernetes` v0.12.0 to `registry-v2.yaml`.
- Latest xk6-kubernetes release (v0.12.0) depends on `go.k6.io/k6/v2 v2.0.0`, confirming k6 v2 support.
- Introduces a new `# Community extensions` section in registry-v2.yaml (first community-tier entry there).
