### PR TITLE
Add version v0.2.0 to xk6-subcommand-agent module

### DIFF
--- a/registry-v2.yaml
+++ b/registry-v2.yaml
@@ -98,6 +98,7 @@
     - agent
   versions:
     - v0.1.2
+    - v0.2.0
 
 - module: github.com/grafana/xk6-subcommand-explore
   description: Explore k6 extensions for Automatic Resolution


### PR DESCRIPTION
Add [v0.2.0](https://github.com/grafana/xk6-subcommand-agent/tree/v0.2.0) of `xk6-subcommand-agent` to the v2 registry.